### PR TITLE
Use const for backend types

### DIFF
--- a/apis/zalando.org/v1/types.go
+++ b/apis/zalando.org/v1/types.go
@@ -36,12 +36,25 @@ type RouteGroupSpec struct {
 	Routes          []RouteGroupRouteSpec        `json:"routes,omitempty"`
 }
 
+// RouteGroupBackendType is the type of the route group backend.
+// +kubebuilder:validation:Enum=service;shunt;loopback;dynamic;lb;network
+type RouteGroupBackendType string
+
+const (
+	ServiceRouteGroupBackend  RouteGroupBackendType = "service"
+	ShuntRouteGroupBackend    RouteGroupBackendType = "shunt"
+	LoopbackRouteGroupBackend RouteGroupBackendType = "loopback"
+	DynamicRouteGroupBackend  RouteGroupBackendType = "dynamic"
+	LBRouteGroupBackend       RouteGroupBackendType = "lb"
+	NetworkRouteGroupBackend  RouteGroupBackendType = "network"
+)
+
 // +k8s:deepcopy-gen=true
 type RouteGroupBackend struct {
 	// Name is the BackendName that can be referenced as RouteGroupBackendReference
 	Name string `json:"name"`
 	// Type is one of "service|shunt|loopback|dynamic|lb|network"
-	Type string `json:"type"`
+	Type RouteGroupBackendType `json:"type"`
 	// Address is required for Type network
 	Address string `json:"address,omitempty"`
 	// Algorithm is required for Type lb


### PR DESCRIPTION
Define a type for the Route Group Backend types and define the different possible values as constants that can be re-used when defining routegroups. This is helpful for ensuring that you don't have a typo in the types.

Similar method is used in the core Kubernetes APIs: https://github.com/kubernetes/kubernetes/blob/99625779295df1e340b4bbc42a23be9abebe064a/staging/src/k8s.io/api/core/v1/types.go#L4756-L4772