### PR TITLE
Mark fields as optional

### DIFF
--- a/apis/zalando.org/v1/types.go
+++ b/apis/zalando.org/v1/types.go
@@ -43,14 +43,18 @@ type RouteGroupBackend struct {
 	// Type is one of "service|shunt|loopback|dynamic|lb|network"
 	Type string `json:"type"`
 	// Address is required for Type network
+	// +optional
 	Address string `json:"address,omitempty"`
 	// Algorithm is required for Type lb
+	// +optional
 	Algorithm string `json:"algorithm,omitempty"`
 	// Endpoints is required for Type lb
 	Endpoints []string `json:"endpoints,omitempty"`
 	// ServiceName is required for Type service
+	// +optional
 	ServiceName string `json:"serviceName,omitempty"`
 	// ServicePort is required for Type service
+	// +optional
 	ServicePort int `json:"servicePort,omitempty"`
 }
 
@@ -60,6 +64,7 @@ type RouteGroupBackendReference struct {
 	BackendName string `json:"backendName"`
 	// Weight defines the traffic weight, if there are 2 or more
 	// default backends
+	// +optional
 	Weight int `json:"weight"`
 }
 


### PR DESCRIPTION
This marks optional fields as optional in a way that the CRD generation understands. This is useful for when the RouteGroup structs are included in other CRDs where the CRD spec is generated with https://github.com/kubernetes-sigs/controller-tools

We use this in stackset-controller