### PR TITLE
Define const for HTTP methods

### DIFF
--- a/apis/zalando.org/v1/types.go
+++ b/apis/zalando.org/v1/types.go
@@ -43,14 +43,18 @@ type RouteGroupBackend struct {
 	// Type is one of "service|shunt|loopback|dynamic|lb|network"
 	Type string `json:"type"`
 	// Address is required for Type network
+	// +optional
 	Address string `json:"address,omitempty"`
 	// Algorithm is required for Type lb
+	// +optional
 	Algorithm string `json:"algorithm,omitempty"`
 	// Endpoints is required for Type lb
 	Endpoints []string `json:"endpoints,omitempty"`
 	// ServiceName is required for Type service
+	// +optional
 	ServiceName string `json:"serviceName,omitempty"`
 	// ServicePort is required for Type service
+	// +optional
 	ServicePort int `json:"servicePort,omitempty"`
 }
 
@@ -60,6 +64,7 @@ type RouteGroupBackendReference struct {
 	BackendName string `json:"backendName"`
 	// Weight defines the traffic weight, if there are 2 or more
 	// default backends
+	// +optional
 	Weight int `json:"weight"`
 }
 

--- a/apis/zalando.org/v1/types.go
+++ b/apis/zalando.org/v1/types.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"net/http"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -68,6 +70,22 @@ type RouteGroupBackendReference struct {
 	Weight int `json:"weight"`
 }
 
+// HTTPMethod is a valid HTTP method in uppercase.
+// +kubebuilder:validation:Enum=GET;HEAD;POST;PUT;PATCH;DELETE;CONNECT;OPTIONS;TRACE
+type HTTPMethod string
+
+const (
+	MethodGet     HTTPMethod = http.MethodGet
+	MethodHead    HTTPMethod = http.MethodHead
+	MethodPost    HTTPMethod = http.MethodPost
+	MethodPut     HTTPMethod = http.MethodPut
+	MethodPatch   HTTPMethod = http.MethodPatch
+	MethodDelete  HTTPMethod = http.MethodDelete
+	MethodConnect HTTPMethod = http.MethodConnect
+	MethodOptions HTTPMethod = http.MethodOptions
+	MethodTrace   HTTPMethod = http.MethodTrace
+)
+
 // +k8s:deepcopy-gen=true
 type RouteGroupRouteSpec struct {
 	// Path specifies Path predicate, only one of Path or PathSubtree is allowed
@@ -81,16 +99,20 @@ type RouteGroupRouteSpec struct {
 
 	// RouteGroupBackendReference specifies the list of backendReference that should
 	// be applied to override the defaultBackends
+	// +optional
 	Backends []RouteGroupBackendReference `json:"backends,omitempty"`
 
 	// Filters specifies the list of filters applied to the routeSpec
+	// +optional
 	Filters []string `json:"filters,omitempty"`
 
 	// Predicates specifies the list of predicates applied to the routeSpec
+	// +optional
 	Predicates []string `json:"predicates,omitempty"`
 
 	// Methods defines valid HTTP methods for the specified routeSpec
-	Methods []string `json:"methods,omitempty"`
+	// +optional
+	Methods []HTTPMethod `json:"methods,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/apis/zalando.org/v1/zz_generated.deepcopy.go
+++ b/apis/zalando.org/v1/zz_generated.deepcopy.go
@@ -165,7 +165,7 @@ func (in *RouteGroupRouteSpec) DeepCopyInto(out *RouteGroupRouteSpec) {
 	}
 	if in.Methods != nil {
 		in, out := &in.Methods, &out.Methods
-		*out = make([]string, len(*in))
+		*out = make([]HTTPMethod, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
Defines HTTP methods as a separate type with consts to be used. Additionally
add the +kubebuilder annotation to allow generating a CRD with enum validation.
It uses the Go net/http standard library for the HTTP method constants.

This is a similar improvement as #2