### PR TITLE
Fix injecting hostname pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(GENERATED_CRD): go.mod $(GENERATED)
 	go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:crdVersions=v1 paths=./apis/... output:crd:dir=.
 	# workaround to add pattern to array items. Not supported by controller-gen
 	# ref: https://github.com/kubernetes-sigs/controller-tools/issues/342
-	perl -i -p0e 's|(\s*)(hosts:.*?items:)|$$1$$2$$1    pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\$$"|g' $(GENERATED_CRD)
+	perl -i -p0e 's|(\s*)(hosts:.*?items:)|$$1$$2$$1    pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\$$"|sg' $(GENERATED_CRD)
 
 build.local: $(LOCAL_BINARIES) $(GENERATED_CRD)
 build.linux: $(LINUX_BINARIES) $(GENERATED_CRD)

--- a/zalando.org_routegroups.yaml
+++ b/zalando.org_routegroups.yaml
@@ -99,6 +99,7 @@ spec:
               hosts:
                 description: List of hostnames for the RouteGroup.
                 items:
+                  pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                   type: string
                 type: array
               routes:


### PR DESCRIPTION
Fixing perl hack introduced along with #5 to inject the hostname pattern.

We do it this way because `sigs.k8s.io/controller-tools` doesn't support setting the pattern on a string slice.