### PR TITLE
Validate backend algorithm with enum

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,15 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2-beta
+      with:
+        go-version: '^1.15'
+    - run: echo "::add-path::$(go env GOPATH)/bin"
+    - run: |
+        make
+        make test

--- a/apis/zalando.org/v1/register.go
+++ b/apis/zalando.org/v1/register.go
@@ -14,12 +14,20 @@ const (
 	GroupVersion = "v1"
 )
 
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme applies all the stored functions to the scheme. A non-nil error
+	// indicates that one function failed and the attempt was abandoned.
+	AddToScheme = schemeBuilder.AddToScheme
+)
+
+// SchemeGroupVersion is the group version used to register these objects.
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 
-var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
-)
+// Resource takes an unqualified resource and returns a Group-qualified GroupResource.
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
 
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,

--- a/apis/zalando.org/v1/types.go
+++ b/apis/zalando.org/v1/types.go
@@ -61,6 +61,18 @@ const (
 	NetworkRouteGroupBackend  RouteGroupBackendType = "network"
 )
 
+// BackendAlgorithmType is the type of algorithm used for load balancing
+// traffic to a backend. This is only valid for backend type lb|service.
+// +kubebuilder:validation:Enum=roundRobin;random;consistentHash;powerOfRandomNChoices
+type BackendAlgorithmType string
+
+const (
+	RoundRobinBackendAlgorithm            BackendAlgorithmType = "roundRobin"
+	RandomBackendAlgorithm                BackendAlgorithmType = "random"
+	ConsistentHashBackendAlgorithm        BackendAlgorithmType = "consistentHash"
+	PowerOfRandomNChoicesBackendAlgorithm BackendAlgorithmType = "powerOfRandomNChoices"
+)
+
 // +k8s:deepcopy-gen=true
 type RouteGroupBackend struct {
 	// Name is the BackendName that can be referenced as RouteGroupBackendReference
@@ -72,7 +84,7 @@ type RouteGroupBackend struct {
 	Address string `json:"address,omitempty"`
 	// Algorithm is required for Type lb
 	// +optional
-	Algorithm string `json:"algorithm,omitempty"`
+	Algorithm BackendAlgorithmType `json:"algorithm,omitempty"`
 	// Endpoints is required for Type lb
 	// +kubebuilder:validation:MinItems=1
 	Endpoints []string `json:"endpoints,omitempty"`

--- a/zalando.org_routegroups.yaml
+++ b/zalando.org_routegroups.yaml
@@ -50,6 +50,11 @@ spec:
                       type: string
                     algorithm:
                       description: Algorithm is required for Type lb
+                      enum:
+                      - roundRobin
+                      - random
+                      - consistentHash
+                      - powerOfRandomNChoices
                       type: string
                     endpoints:
                       description: Endpoints is required for Type lb


### PR DESCRIPTION
Introduces dedicated type for `algorirthm` and adds enum to prevent users from defining invalid algorithms.

Additionally:

* Fix generated code
* Add github action based build to ensure everything is building as expected (https://github.com/mikkeloscar/routegroup-client/runs/1384522103?check_suite_focus=true)