### PR TITLE
crd: update backend description

### DIFF
--- a/zalando.org_routegroups.yaml
+++ b/zalando.org_routegroups.yaml
@@ -52,10 +52,22 @@ spec:
                 items:
                   properties:
                     address:
-                      description: Address is required for Type network
+                      description: Address is required for type `network`
                       type: string
                     algorithm:
-                      description: Algorithm is required for Type lb
+                      description: Algorithm is required for type `lb`. `roundRobin`
+                        - backend is chosen by the round robin algorithm, starting
+                        with a random selected backend to spread across all backends
+                        from the beginning. `random` - backend is chosen at random.
+                        `consistentHash` - backend is chosen by [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing)
+                        algorithm based on the request key. The request key is derived
+                        from `X-Forwarded-For` header or request remote IP address
+                        as the fallback. Use [`consistentHashKey`](filters.md#consistenthashkey)
+                        filter to set the request key. Use [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor)
+                        to prevent popular keys from overloading a single backend
+                        endpoint. `powerOfRandomNChoices` - backend is chosen by selecting
+                        N random endpoints and picking the one with least outstanding
+                        requests from them (see http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).
                       enum:
                       - roundRobin
                       - random
@@ -63,7 +75,7 @@ spec:
                       - powerOfRandomNChoices
                       type: string
                     endpoints:
-                      description: Endpoints is required for Type lb
+                      description: Endpoints is required for type `lb`
                       items:
                         type: string
                       minItems: 1
@@ -73,13 +85,29 @@ spec:
                         as RouteGroupBackendReference
                       type: string
                     serviceName:
-                      description: ServiceName is required for Type service
+                      description: ServiceName is required for type `service`
                       type: string
                     servicePort:
-                      description: ServicePort is required for Type service
+                      description: ServicePort is required for type `service`
                       type: integer
                     type:
-                      description: Type is one of "service|shunt|loopback|dynamic|lb|network"
+                      description: Type of the backend. `service`- resolve Kubernetes
+                        service to the available Endpoints belonging to the Service,
+                        and generate load balanced routes using them. `shunt` - reply
+                        directly from the proxy itself. This can be used to shortcut,
+                        for example have a default that replies with 404 or use skipper
+                        as a backend serving static content in demos. `loopback` -
+                        lookup again the routing table to a better matching route
+                        after processing the current route. Like this you can add
+                        some headers or change the request path for some specific
+                        matching requests. `dynamic` - use the backend provided by
+                        filters. This allows skipper as library users to do proxy
+                        calls to a certain target from their own implementation dynamically
+                        looked up by their filters. `lb` - balance the load across
+                        multiple network endpoints using specified algorithm. If algorithm
+                        is not specified it will use the default algorithm set by
+                        Skipper at start. `network` - use arbitrary HTTP or HTTPS
+                        URL.
                       enum:
                       - service
                       - shunt


### PR DESCRIPTION
Example `kubectl explain` output:
```
...
   algorithm    <string>
     Algorithm is required for type `lb`. `roundRobin` - backend is chosen by
     the round robin algorithm, starting with a random selected backend to
     spread across all backends from the beginning. `random` - backend is chosen
     at random. `consistentHash` - backend is chosen by [consistent
     hashing](https://en.wikipedia.org/wiki/Consistent_hashing) algorithm based
     on the request key. The request key is derived from `X-Forwarded-For`
     header or request remote IP address as the fallback. Use
     [`consistentHashKey`](filters.md#consistenthashkey) filter to set the
     request key. Use
     [`consistentHashBalanceFactor`](filters.md#consistenthashbalancefactor) to
     prevent popular keys from overloading a single backend endpoint.
     `powerOfRandomNChoices` - backend is chosen by selecting N random endpoints and picking the one with least
     outstanding requests from them (see
     http://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf).

...
   type <string> -required-
     Type of the backend. `service`- resolve Kubernetes service to the available
     Endpoints belonging to the Service, and generate load balanced routes using
     them. `shunt` - reply directly from the proxy itself. This can be used to
     shortcut, for example have a default that replies with 404 or use skipper
     as a backend serving static content in demos. `loopback` - lookup again the
     routing table to a better matching route after processing the current
     route. Like this you can add some headers or change the request path for
     some specific matching requests. `dynamic` - use the backend provided by
     filters. This allows skipper as library users to do proxy calls to a
     certain target from their own implementation dynamically looked up by their
     filters. `lb` - balance the load across multiple network endpoints using
     specified algorithm. If algorithm is not specified it will use the default
     algorithm set by Skipper at start. `network` - use arbitrary HTTP or HTTPS
     URL.
```