### PR TITLE
Update client to use `BearerTokenFile` when needed

### DIFF
--- a/cli/rg-client-test/main.go
+++ b/cli/rg-client-test/main.go
@@ -12,17 +12,21 @@ import (
 )
 
 func main() {
-	cli, err := rgclient.CreateUnified()
+	cli, err := rgclient.CreateUnifiedWithOptions(&rgclient.Options{TokenFile: "/tmp/k8s_token"})
 	if err != nil {
 		log.Fatalf("Failed to create unified RouteGroup client: %v", err)
 	}
 	log.Println("have cli")
 
 	// example kubernetes.Interface access
-	ings, err := cli.ExtensionsV1beta1().Ingresses("").List(context.TODO(), metav1.ListOptions{})
-	//ings, err := cli.NetworkingV1().Ingress("").List(context.TODO(), metav1.ListOptions{})
+	// ings, err := cli.ExtensionsV1beta1().Ingresses("").List(context.TODO(), metav1.ListOptions{})
+	ings, err := cli.NetworkingV1().Ingresses("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Fatalf("Failed to get Ingress list: %v", err)
+	}
+
 	for _, ing := range ings.Items {
-		log.Printf("ing NAmespace/Name: %s/%s", ing.Namespace, ing.Name)
+		log.Printf("ing Namespace/Name: %s/%s\n", ing.Namespace, ing.Name)
 	}
 	log.Printf("have ing %d", len(ings.Items))
 

--- a/cli/rg-client-test/main.go
+++ b/cli/rg-client-test/main.go
@@ -13,6 +13,7 @@ import (
 
 func main() {
 	cli, err := rgclient.CreateUnifiedWithOptions(&rgclient.Options{TokenFile: "/tmp/k8s_token"})
+	// cli, err := rgclient.CreateUnified()
 	if err != nil {
 		log.Fatalf("Failed to create unified RouteGroup client: %v", err)
 	}

--- a/client.go
+++ b/client.go
@@ -64,7 +64,7 @@ func NewClientset(config *rest.Config) (*Clientset, error) {
 
 // Create returns the Zalandointerface client
 func Create() (ZalandoInterface, error) {
-	config, err := getRestConfig()
+	config, err := getRestConfigWithOptions(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func Create() (ZalandoInterface, error) {
 
 // CreateUnified returns the unified client
 func CreateUnified() (Interface, error) {
-	config, err := getRestConfig()
+	config, err := getRestConfigWithOptions(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,28 +102,19 @@ func CreateUnifiedWithOptions(opts *Options) (Interface, error) {
 	return client, nil
 }
 
-func getRestConfig() (*rest.Config, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		if errors.Is(err, rest.ErrNotInCluster) {
-			config = &rest.Config{
-				Host: LocalAPIServer,
-			}
-			err = nil
-		} else {
-			return nil, err
-		}
-	}
-	return config, err
-}
-
 func getRestConfigWithOptions(opts *Options) (*rest.Config, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		if errors.Is(err, rest.ErrNotInCluster) {
-			config = &rest.Config{
-				Host:            LocalAPIServer,
-				BearerTokenFile: opts.TokenFile,
+			if opts == nil {
+				config = &rest.Config{
+					Host: LocalAPIServer,
+				}
+			} else {
+				config = &rest.Config{
+					Host:            LocalAPIServer,
+					BearerTokenFile: opts.TokenFile,
+				}
 			}
 			err = nil
 		} else {

--- a/client.go
+++ b/client.go
@@ -87,7 +87,7 @@ func CreateUnified() (Interface, error) {
 	return client, nil
 }
 
-// CreateUnified returns the unified client
+// CreateUnifiedWithOptions returns the unified client that
 func CreateUnifiedWithOptions(opts *Options) (Interface, error) {
 	config, err := getRestConfigWithOptions(opts)
 	if err != nil {


### PR DESCRIPTION
With this PR we should be able to lunch the client with different Options or none, it tries to resemble https://github.com/zalando/skipper/pull/2590 so requests could be authorized with tokens outside clusters.

Without this PR I get `2023/10/04 17:55:21 Failed to get Ingress list: Unauthorized` in the example, could hack around and try to use `/var/run/secrets/kubernetes.io/serviceaccount/token` but this also didn't work