### PR TITLE
crd: add minItems for hosts

### DIFF
--- a/apis/zalando.org/v1/types.go
+++ b/apis/zalando.org/v1/types.go
@@ -42,6 +42,7 @@ type RouteGroupList struct {
 // +k8s:deepcopy-gen=true
 type RouteGroupSpec struct {
 	// List of hostnames for the RouteGroup
+	// +kubebuilder:validation:MinItems=1
 	Hosts []string `json:"hosts,omitempty"`
 	// List of backends that can be referenced in the routes
 	Backends []RouteGroupBackend `json:"backends"`

--- a/zalando.org_routegroups.yaml
+++ b/zalando.org_routegroups.yaml
@@ -134,6 +134,7 @@ spec:
                 items:
                   pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
                   type: string
+                minItems: 1
                 type: array
               routes:
                 description: Routes describe how a matching HTTP request is handled


### PR DESCRIPTION
The hosts field is not required but it should have at least one item when specified.